### PR TITLE
Lv3. 검색 결과 없음 처리

### DIFF
--- a/ExchangesApp/Sources/View/ExchangeRateViewController.swift
+++ b/ExchangesApp/Sources/View/ExchangeRateViewController.swift
@@ -19,6 +19,14 @@ final class ExchangeRateViewController: UIViewController {
         return table
     }()
 
+    private let noResultLabel = UILabel().then {
+        $0.text = "검색 결과 없음"
+        $0.textAlignment = .center
+        $0.textColor = .gray
+        $0.font = .systemFont(ofSize: 16, weight: .regular)
+        $0.isHidden = true
+    }
+
     private let viewModel = ExchangeRateViewModel()
 
     override func viewDidLoad() {
@@ -34,10 +42,10 @@ final class ExchangeRateViewController: UIViewController {
 
         view.addSubview(searchBar)
         view.addSubview(tableView)
+        view.addSubview(noResultLabel)
 
         searchBar.delegate = self
-        searchBar.placeholder = "통화 코드 또는 국가명 검색"
-
+        searchBar.placeholder = "통화 검색"
         searchBar.backgroundImage = UIImage()
 
         searchBar.snp.makeConstraints { make in
@@ -50,13 +58,21 @@ final class ExchangeRateViewController: UIViewController {
             make.leading.trailing.bottom.equalTo(view.safeAreaLayoutGuide) // 좌우 하단
         }
 
+        noResultLabel.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+            make.leading.greaterThanOrEqualToSuperview().offset(16)
+            make.trailing.lessThanOrEqualToSuperview().offset(-16)
+        }
+
         tableView.dataSource = self // 데이터 소스
     }
 
     private func bindViewModel() {
         // 데이터 업데이트 했을 때 테이블뷰 갱신
         viewModel.onUpdate = { [weak self] in
-            self?.tableView.reloadData()
+            guard let self = self else { return }
+            self.tableView.reloadData()
+            self.noResultLabel.isHidden = !self.viewModel.filteredItems.isEmpty
         }
 
         // 에러 발생 알림
@@ -69,19 +85,15 @@ final class ExchangeRateViewController: UIViewController {
 }
 
 extension ExchangeRateViewController: UITableViewDataSource {
-    // 행 개수
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return viewModel.filteredItems.count
     }
-
-    // 행에 표시할 셀
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: ExchangeRateCell.identifier, for: indexPath) as? ExchangeRateCell else {
             return UITableViewCell()
         }
-
         let model = viewModel.filteredItems[indexPath.row]
-        cell.configure(with: model) // 셀에 데이터 전달 UI 업뎃
+        cell.configure(with: model)
         return cell
     }
 }


### PR DESCRIPTION
통화 코드 || 국가명을 기준으로 실시간 환율 목록을 필터링할 수 있도록 검색 기능 추가

검색 결과가 없을 경우 "검색 결과 없음"이라는 레이블 띄움

UISearchBar 입력에 따라 filteredItems를 필터링하도록 ViewModel에 search(query:) 메서드 구현

검색 결과가 없을 경우 UITableViewCell 대신 별도의 UILabel(noResultLabel)을 중앙에 표시

ExchangeRateViewController 내 bindViewModel()에서 filteredItems.isEmpty 조건에 따라 noResultLabel의 표시 여부를 업데이트

![Simulator Screen Recording - iPhone 16 Pro - 2025-07-09 at 21 01 22](https://github.com/user-attachments/assets/b3375e1a-103b-4e64-892a-d9c6862a3fc6)