### PR TITLE
Lv4_chore 뒤로가기 버튼 타이틀을 환율 정보로 설정

### DIFF
--- a/ExchangesApp/Sources/ExchangeRate/ExchangeRateViewController.swift
+++ b/ExchangesApp/Sources/ExchangeRate/ExchangeRateViewController.swift
@@ -31,6 +31,7 @@ final class ExchangeRateViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.navigationItem.title = "환율 정보"
         setupUI() // UI 초기 설정
         bindViewModel() // 뷰 모델이랑 바인딩
         viewModel.fetchRates() // 환율 데이터 요청


### PR DESCRIPTION
## 변경 사항

- `CalculatorViewController`에서 뒤로가기 버튼 텍스트가 `환율 정보`로 표시되도록 개선