### PR TITLE
Lv7. 즐겨찾기 기능 추가

### DIFF
--- a/ExchangesApp/ExchangesApp.xcdatamodeld/.xccurrentversion
+++ b/ExchangesApp/ExchangesApp.xcdatamodeld/.xccurrentversion
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>_XCCurrentVersionName</key>
-	<string>ExchangesApp.xcdatamodel</string>
-</dict>
-</plist>

--- a/ExchangesApp/ExchangesApp.xcdatamodeld/ExchangesApp.xcdatamodel/contents
+++ b/ExchangesApp/ExchangesApp.xcdatamodeld/ExchangesApp.xcdatamodel/contents
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="1" systemVersion="11A491" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithCloudKit="false" userDefinedModelVersionIdentifier="">
-    <elements/>
-</model>

--- a/ExchangesApp/Sources/Data/CoreDataManager.swift
+++ b/ExchangesApp/Sources/Data/CoreDataManager.swift
@@ -1,0 +1,41 @@
+//
+//  CoreDataManager.swift
+//  ExchangesApp
+//
+//  Created by 노가현 on 7/11/25.
+//
+
+import CoreData
+import UIKit
+
+final class CoreDataManager {
+    static let shared = CoreDataManager()
+    private let context = (UIApplication.shared.delegate as! AppDelegate).persistentContainer.viewContext
+
+    func isFavorite(code: String) -> Bool {
+        let request: NSFetchRequest<FavoriteCurrency> = FavoriteCurrency.fetchRequest()
+        request.predicate = NSPredicate(format: "code == %@", code)
+        return (try? context.count(for: request)) ?? 0 > 0
+    }
+
+    func addFavorite(code: String) {
+        let favorite = FavoriteCurrency(context: context)
+        favorite.code = code
+        try? context.save()
+    }
+
+    func removeFavorite(code: String) {
+        let request: NSFetchRequest<FavoriteCurrency> = FavoriteCurrency.fetchRequest()
+        request.predicate = NSPredicate(format: "code == %@", code)
+        if let result = try? context.fetch(request).first {
+            context.delete(result)
+            try? context.save()
+        }
+    }
+
+    func getAllFavorites() -> [String] {
+        let request: NSFetchRequest<FavoriteCurrency> = FavoriteCurrency.fetchRequest()
+        let result = (try? context.fetch(request)) ?? []
+        return result.compactMap { $0.code }
+    }
+}

--- a/ExchangesApp/Sources/Data/ExchangesApp.xcdatamodeld/ExchangesApp.xcdatamodel/contents
+++ b/ExchangesApp/Sources/Data/ExchangesApp.xcdatamodeld/ExchangesApp.xcdatamodel/contents
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23788.4" systemVersion="24F74" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
+    <entity name="FavoriteCurrency" representedClassName="FavoriteCurrency" syncable="YES" codeGenerationType="class">
+        <attribute name="code" optional="YES" attributeType="String"/>
+    </entity>
+</model>

--- a/ExchangesApp/Sources/ExchangeRate/ExchangeRateCell.swift
+++ b/ExchangesApp/Sources/ExchangeRate/ExchangeRateCell.swift
@@ -32,6 +32,14 @@ final class ExchangeRateCell: UITableViewCell {
         $0.setContentCompressionResistancePriority(.required, for: .horizontal)
     }
 
+    private let favoriteButton = UIButton().then {
+        $0.tintColor = .systemYellow
+        $0.setContentHuggingPriority(.required, for: .horizontal)
+        $0.setContentCompressionResistancePriority(.required, for: .horizontal)
+    }
+
+    var onFavoriteToggle: (() -> Void)?
+
     private let labelStackView = UIStackView().then {
         $0.axis = .vertical
         $0.spacing = 4
@@ -40,6 +48,7 @@ final class ExchangeRateCell: UITableViewCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         setupLayout()
+        favoriteButton.addTarget(self, action: #selector(favoriteTapped), for: .touchUpInside)
     }
 
     required init?(coder: NSCoder) {
@@ -56,11 +65,15 @@ final class ExchangeRateCell: UITableViewCell {
         formatter.maximumFractionDigits = 4
         formatter.groupingSeparator = ""
 
-        if let formatted = formatter.string(from: NSNumber(value: model.rate)) {
-            rateLabel.text = formatted
-        } else {
-            rateLabel.text = String(format: "%.4f", model.rate)
-        }
+        rateLabel.text = formatter.string(from: NSNumber(value: model.rate)) ?? String(format: "%.4f", model.rate)
+
+        let starImage = model.isFavorite ? "star.fill" : "star"
+        favoriteButton.setImage(UIImage(systemName: starImage), for: .normal)
+
+    }
+
+    @objc private func favoriteTapped() {
+        onFavoriteToggle?()
     }
 
     private func setupLayout() {
@@ -69,6 +82,7 @@ final class ExchangeRateCell: UITableViewCell {
 
         contentView.addSubview(labelStackView)
         contentView.addSubview(rateLabel)
+        contentView.addSubview(favoriteButton)
 
         // contentView 높이 제약 조건
         contentView.snp.makeConstraints {
@@ -80,14 +94,20 @@ final class ExchangeRateCell: UITableViewCell {
         labelStackView.snp.makeConstraints {
             $0.leading.equalToSuperview().offset(16)
             $0.centerY.equalToSuperview()
+            $0.trailing.lessThanOrEqualTo(rateLabel.snp.leading).offset(-8)
+        }
+
+        favoriteButton.snp.makeConstraints {
+            $0.trailing.equalToSuperview().offset(-16)
+            $0.centerY.equalToSuperview()
+            $0.width.height.equalTo(24)
         }
 
         // rateLabel 제약 조건
         rateLabel.snp.makeConstraints {
-            $0.trailing.equalToSuperview().offset(-16)
+            $0.trailing.equalTo(favoriteButton.snp.leading).offset(-8)
             $0.centerY.equalToSuperview()
-            $0.leading.greaterThanOrEqualTo(labelStackView.snp.trailing).offset(16)
-            $0.width.equalTo(120)
+            $0.width.lessThanOrEqualTo(100)
         }
     }
 }

--- a/ExchangesApp/Sources/ExchangeRate/ExchangeRateViewController.swift
+++ b/ExchangesApp/Sources/ExchangeRate/ExchangeRateViewController.swift
@@ -12,6 +12,14 @@ import RxSwift
 import RxCocoa
 
 final class ExchangeRateViewController: UIViewController {
+    private let viewModel = ExchangeRateViewModel()
+    private let disposeBag = DisposeBag()
+
+    private let tableView = UITableView().then {
+        $0.rowHeight = 60
+        $0.register(ExchangeRateCell.self, forCellReuseIdentifier: ExchangeRateCell.identifier) // 셀 등록
+    }
+
     private let titleLabel = UILabel().then {
         $0.text = "환율 정보"
         $0.font = .systemFont(ofSize: 36, weight: .bold)
@@ -22,11 +30,6 @@ final class ExchangeRateViewController: UIViewController {
         $0.backgroundImage = UIImage()
     }
 
-    private let tableView = UITableView().then {
-        $0.rowHeight = 60
-        $0.register(ExchangeRateCell.self, forCellReuseIdentifier: ExchangeRateCell.identifier) // 셀 등록
-    }
-
     private let noResultLabel = UILabel().then {
         $0.text = "검색 결과 없음"
         $0.textAlignment = .center
@@ -35,15 +38,13 @@ final class ExchangeRateViewController: UIViewController {
         $0.isHidden = true
     }
 
-    private let viewModel = ExchangeRateViewModel()
-    private let disposeBag = DisposeBag()
-
     override func viewDidLoad() {
         super.viewDidLoad()
         self.navigationItem.title = "환율 정보"
         setupUI() // UI 초기 설정
         bindViewModel() // 뷰 모델이랑 바인딩
         viewModel.fetchRates() // 환율 데이터 요청
+        bindSearchBar()
     }
 
     private func setupUI() {
@@ -107,6 +108,10 @@ extension ExchangeRateViewController: UITableViewDataSource {
         }
         let model = viewModel.filteredItems[indexPath.row]
         cell.configure(with: model)
+
+        cell.onFavoriteToggle = { [weak self] in
+            self?.viewModel.toggleFavorite(for: indexPath.row)
+        }
         return cell
     }
 }

--- a/ExchangesApp/Sources/ExchangeRate/ExchangeRateViewModel.swift
+++ b/ExchangesApp/Sources/ExchangeRate/ExchangeRateViewModel.swift
@@ -16,11 +16,14 @@ final class ExchangeRateViewModel {
     var onUpdate: (() -> Void)? // 데이터 갱신 했을 때 호출
     var onError: ((String) -> Void)? // 에러 발생했을 때 호출
 
+    private var currentQuery: String = ""
+
     func fetchRates(base: String = "USD") {
         service.fetchRates(base: base) { [weak self] result in
             DispatchQueue.main.async {
                 switch result {
                 case .success(let dict):
+                    let favorites = Set(CoreDataManager.shared.getAllFavorites())
                     // 통화 코드에 맞는 국가명 매핑
                     let mapper = CurrencyCountryMapper.shared
 
@@ -29,13 +32,13 @@ final class ExchangeRateViewModel {
                         ExchangeRateDisplayModel(
                             currencyCode: code,
                             countryName: mapper.country(for: code), // 국가명
-                            rate: rate
+                            rate: rate,
+                            isFavorite: favorites.contains(code)
                         )
                     }.sorted { $0.currencyCode < $1.currencyCode }
 
                     self?.allItems = models
-                    self?.filteredItems = models
-                    self?.onUpdate?() // UI 갱신
+                    self?.applyFilter(query: self?.currentQuery ?? "")
 
                 case .failure:
                     self?.onError?("데이터를 불러올 수 없습니다")
@@ -46,20 +49,42 @@ final class ExchangeRateViewModel {
 
     // 검색어 기반 환율 데이터 필터링
     func search(query: String) {
-        // 비어 있으면 전체 목록으로
-        guard !query.isEmpty else {
-            filteredItems = allItems
-            onUpdate?()
-            return
+        currentQuery = query
+        applyFilter(query: query)
+    }
+
+    func toggleFavorite(for index: Int) {
+        var model = filteredItems[index]
+        model.isFavorite.toggle()
+
+        if model.isFavorite {
+            CoreDataManager.shared.addFavorite(code: model.currencyCode)
+        } else {
+            CoreDataManager.shared.removeFavorite(code: model.currencyCode)
+        }
+        if let allIndex = allItems.firstIndex(where: { $0.currencyCode == model.currencyCode }) {
+            allItems[allIndex] = model
         }
 
-        let lowercased = query.lowercased()
+        applyFilter(query: currentQuery)
+    }
 
-        // 통화코드 || 국가명에 검색어 포함 필터링
+    private func applyFilter(query: String) {
+        let lower = query.lowercased()
+
         filteredItems = allItems.filter {
-            $0.currencyCode.lowercased().contains(lowercased) ||
-            $0.countryName.lowercased().contains(lowercased)
+            query.isEmpty ||
+            $0.currencyCode.lowercased().contains(lower) ||
+            $0.countryName.lowercased().contains(lower)
         }
+        .sorted {
+            if $0.isFavorite == $1.isFavorite {
+                return $0.currencyCode < $1.currencyCode
+            }
+            return $0.isFavorite && !$1.isFavorite
+        }
+
         onUpdate?()
     }
 }
+

--- a/ExchangesApp/Sources/Model/ExchangeRateDisplayModel.swift
+++ b/ExchangesApp/Sources/Model/ExchangeRateDisplayModel.swift
@@ -11,4 +11,5 @@ struct ExchangeRateDisplayModel {
     let currencyCode: String // 통화 코드
     let countryName: String // 통화의 국가 이름
     let rate: Double // 환율 값
+    var isFavorite: Bool
 }


### PR DESCRIPTION
## 구현 내용
- 통화 셀 우측에 즐겨찾기 버튼(⭐️ / ☆) 추가
- 사용한 SF Symbol : star.fill / star
- 즐겨찾기 상태에 따라 UI 업데이트

- ⭐️ 클릭 시 CoreData에 즐겨찾기 상태 저장/삭제
- `CoreDataManager`를 통해 즐겨찾기 상태 관리 (`isFavorite`, `addFavorite`, `removeFavorite`)

- 리스트 출력 시 즐겨찾기된 통화를 **상단에 고정**
- 즐겨찾기된 항목 → 알파벳 오름차순 정렬
- 비즐겨찾기 항목 → 알파벳 오름차순 정렬
- 정렬된 두 리스트를 합쳐 `filteredItems`에 적용

- ViewModel에서 `toggleFavorite(code:)` 함수로 즐겨찾기 처리
- 테이블 뷰 reload 처리 && UI 업데이트 연동 완료
- CoreData Entity : `FavoriteCurrency`, key: `code: String`

![Simulator Screen Recording - iPhone 16 Pro - 2025-07-11 at 19 23 25](https://github.com/user-attachments/assets/7285e5aa-5671-4005-93b0-7772743412b4)