### PR TITLE
Lv9. 다크모드 구현

### DIFF
--- a/ExchangesApp.xcodeproj/xcshareddata/xcschemes/ExchangesApp.xcscheme
+++ b/ExchangesApp.xcodeproj/xcshareddata/xcschemes/ExchangesApp.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1640"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "367508D82E1B6A9E004A775E"
+               BuildableName = "ExchangesApp.app"
+               BlueprintName = "ExchangesApp"
+               ReferencedContainer = "container:ExchangesApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "367508D82E1B6A9E004A775E"
+            BuildableName = "ExchangesApp.app"
+            BlueprintName = "ExchangesApp"
+            ReferencedContainer = "container:ExchangesApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "367508D82E1B6A9E004A775E"
+            BuildableName = "ExchangesApp.app"
+            BlueprintName = "ExchangesApp"
+            ReferencedContainer = "container:ExchangesApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ExchangesApp/Sources/Calculator/CalculatorViewController.swift
+++ b/ExchangesApp/Sources/Calculator/CalculatorViewController.swift
@@ -36,14 +36,22 @@ final class CalculatorViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .white
+        view.backgroundColor = .systemBackground
         setupUI()
+
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+        view.addGestureRecognizer(tapGesture)
+    }
+
+    @objc private func dismissKeyboard() {
+        view.endEditing(true)
     }
 
     private func setupUI() {
         titleLabel.text = "환율 계산기"
         titleLabel.font = UIFont.systemFont(ofSize: 36, weight: .bold)
         titleLabel.textAlignment = .left
+        titleLabel.textColor = .label
 
         // 상단 통화/국가 레이블 스택
         let labelStack = UIStackView(arrangedSubviews: [currencyLabel, countryLabel])
@@ -54,9 +62,10 @@ final class CalculatorViewController: UIViewController {
         // 레이블 세팅
         currencyLabel.font = .systemFont(ofSize: 24, weight: .bold)
         currencyLabel.text = currencyCode
+        currencyLabel.textColor = .label
 
         countryLabel.font = .systemFont(ofSize: 16)
-        countryLabel.textColor = .gray
+        countryLabel.textColor = .secondaryLabel
         countryLabel.text = countryName
 
         // 입력창 세팅
@@ -64,6 +73,8 @@ final class CalculatorViewController: UIViewController {
         amountTextField.keyboardType = .decimalPad
         amountTextField.textAlignment = .center
         amountTextField.placeholder = "달러(USD)를 입력하세요"
+        amountTextField.backgroundColor = .secondarySystemBackground
+        amountTextField.textColor = .label
 
         // 버튼 세팅
         convertButton.backgroundColor = .systemBlue
@@ -78,6 +89,7 @@ final class CalculatorViewController: UIViewController {
         resultLabel.textAlignment = .center
         resultLabel.numberOfLines = 0
         resultLabel.text = "계산 결과가 여기에 표시됩니다"
+        resultLabel.textColor = .label
 
         [titleLabel, labelStack, amountTextField, convertButton, resultLabel].forEach {
             view .addSubview($0)

--- a/ExchangesApp/Sources/ExchangeRate/ExchangeRateCell.swift
+++ b/ExchangesApp/Sources/ExchangeRate/ExchangeRateCell.swift
@@ -19,7 +19,7 @@ final class ExchangeRateCell: UITableViewCell {
 
     private let countryLabel = UILabel().then {
         $0.font = .systemFont(ofSize: 14)
-        $0.textColor = .gray
+        $0.textColor = .secondaryLabel
         $0.lineBreakMode = .byTruncatingTail
     }
 
@@ -49,6 +49,8 @@ final class ExchangeRateCell: UITableViewCell {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         setupLayout()
         favoriteButton.addTarget(self, action: #selector(favoriteTapped), for: .touchUpInside)
+        backgroundColor = .systemBackground
+        contentView.backgroundColor = .systemBackground
     }
 
     required init?(coder: NSCoder) {

--- a/ExchangesApp/Sources/ExchangeRate/ExchangeRateViewController.swift
+++ b/ExchangesApp/Sources/ExchangeRate/ExchangeRateViewController.swift
@@ -18,29 +18,36 @@ final class ExchangeRateViewController: UIViewController {
     private let tableView = UITableView().then {
         $0.rowHeight = 60
         $0.register(ExchangeRateCell.self, forCellReuseIdentifier: ExchangeRateCell.identifier) // 셀 등록
+        $0.backgroundColor = .systemBackground
     }
 
     private let titleLabel = UILabel().then {
         $0.text = "환율 정보"
         $0.font = .systemFont(ofSize: 36, weight: .bold)
         $0.textAlignment = .left
+        $0.textColor = .label
     }
     private let searchBar = UISearchBar().then { // 검색
         $0.placeholder = "통화 검색"
         $0.backgroundImage = UIImage()
+        $0.barTintColor = .systemBackground
+        $0.searchTextField.backgroundColor = .secondarySystemBackground
+        $0.searchTextField.textColor = .label
     }
 
     private let noResultLabel = UILabel().then {
         $0.text = "검색 결과 없음"
         $0.textAlignment = .center
-        $0.textColor = .gray
+        $0.textColor = .secondaryLabel
         $0.font = .systemFont(ofSize: 16)
         $0.isHidden = true
     }
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        view.backgroundColor = .systemBackground
         self.navigationItem.title = "환율 정보"
+
         setupUI() // UI 초기 설정
         bindViewModel() // 뷰 모델이랑 바인딩
         viewModel.fetchRates() // 환율 데이터 요청
@@ -48,7 +55,6 @@ final class ExchangeRateViewController: UIViewController {
     }
 
     private func setupUI() {
-        view.backgroundColor = .white
         [titleLabel, searchBar, tableView, noResultLabel].forEach { view.addSubview($0) }
 
         tableView.backgroundView = noResultLabel


### PR DESCRIPTION
## 다크모드 UI 구현

- 시스템 색상 (.label, .systemBackground, .secondaryLabel, .secondarySystemBackground 등) 사용하여 다크모드 대응 UI 구현

- 기존의 .white, .black, .gray 등 하드코딩된 색상 제거

- 검색창의 텍스트필드 및 placeholder 색상도 다크모드 대응

![Simulator Screen Recording - iPhone 16 Pro - 2025-07-12 at 00 26 13](https://github.com/user-attachments/assets/163e995b-6746-472b-84d1-80e40ab796bf)